### PR TITLE
Fix bug where packets are not handled on the server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .gradle/
 build/
 bin/
+classes/
 out/
 run/*
 

--- a/src/main/java/com/flansmod/common/PlayerData.java
+++ b/src/main/java/com/flansmod/common/PlayerData.java
@@ -14,11 +14,12 @@ import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
 import java.util.ArrayList;
+import java.util.UUID;
 
 public class PlayerData 
 {
-	/** Their username */
-	public String username;
+	/** Their uuid */
+	private final UUID uniqueId;
 
 	//Movement related fields
 	/** Roll variables */
@@ -118,9 +119,9 @@ public class PlayerData
 	@SideOnly(Side.CLIENT)
 	public ResourceLocation skin;
 	
-	public PlayerData(String name) 
+	public PlayerData(UUID uuid)
 	{
-		username = name;	
+		uniqueId = uuid;
 		snapshots = new PlayerSnapshot[FlansMod.numPlayerSnapshots];
 	}
 	

--- a/src/main/java/com/flansmod/common/network/PacketHandler.java
+++ b/src/main/java/com/flansmod/common/network/PacketHandler.java
@@ -1,15 +1,6 @@
 package com.flansmod.common.network;
 
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.EnumMap;
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.concurrent.ConcurrentLinkedQueue;
-
 import com.flansmod.common.FlansMod;
-
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandler;
@@ -29,6 +20,9 @@ import net.minecraftforge.fml.common.network.NetworkRegistry;
 import net.minecraftforge.fml.common.network.internal.FMLProxyPacket;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
+
+import java.util.*;
+import java.util.concurrent.ConcurrentLinkedQueue;
 
 /** 
  * Flan's Mod packet handler class. Directs packet data to packet classes.
@@ -127,7 +121,7 @@ public class PacketHandler extends MessageToMessageCodec<FMLProxyPacket, PacketB
 			/*if(!receivedPacketsServer.containsKey(player.getName()))
 				receivedPacketsServer.put(player.getName(), new ConcurrentLinkedQueue<PacketBase>());
 			receivedPacketsServer.get(player.getName()).offer(packet);*/
-			getConcurrentLinkedQueue(player.getName()).offer(packet);
+			getConcurrentLinkedQueue(player.getUniqueID()).offer(packet);
 			
 			//packet.handleServerSide();
 			
@@ -159,43 +153,50 @@ public class PacketHandler extends MessageToMessageCodec<FMLProxyPacket, PacketB
 		}
 	}*/
 	//NEW CODE START
-	private static HashSet<PlayerQueue> receivedPacketsServer = new HashSet<PlayerQueue>();
+	private static HashMap<UUID, PlayerQueue> receivedPacketsServer = new HashMap<>();
 	
-	private boolean contains(String name){
+	private boolean contains(UUID uuid){
+		/*
 		for(PlayerQueue pq : receivedPacketsServer){
-			if(pq.player.getName().equals(name)){
+			if(pq.player.getUniqueID().equals(uuid)){
 				return true;
 			}
 		}
 		return false;
+		*/
+		return receivedPacketsServer.containsKey(uuid);
 	}
-	
+
+
 	public static void add(EntityPlayerMP player){
-		receivedPacketsServer.add(new PlayerQueue(player));
+		receivedPacketsServer.put(player.getUniqueID(), new PlayerQueue(player));
 	}
 	
-	private ConcurrentLinkedQueue<PacketBase> getConcurrentLinkedQueue(String name){
-		for(PlayerQueue pq : receivedPacketsServer){
-			if(pq.player.getName().equals(name)){
+	private ConcurrentLinkedQueue<PacketBase> getConcurrentLinkedQueue(UUID uuid){
+		for(PlayerQueue pq : receivedPacketsServer.values()){
+			if(pq.player.getUniqueID().equals(uuid)){
 				return pq.packetQueue;
 			}
 		}
 		return null;
 	}
 	
-	public static void tryRemove(String name){
+	public static void tryRemove(UUID uuid){
+		/*
 		PlayerQueue toRemove = null;
-		for(PlayerQueue pq : receivedPacketsServer){
-			if(pq.player.getName().equals(name)){
+		for(PlayerQueue pq : receivedPacketsServer.values()){
+			if(pq.player.getUniqueID().equals(uuid)){
 				toRemove = pq;
 				break;
 			}
 		}
 		receivedPacketsServer.remove(toRemove);
+		*/
+		receivedPacketsServer.remove(uuid);
 	}
 	
 	public void handleServerPackets(){
-		for(PlayerQueue pq : receivedPacketsServer){
+		for(PlayerQueue pq : receivedPacketsServer.values()){
 			for(PacketBase packet = pq.packetQueue.poll(); packet != null; packet = pq.packetQueue.poll()){
 				packet.handleServerSide(pq.player);
 			}

--- a/src/main/java/com/flansmod/common/network/PacketTeamInfo.java
+++ b/src/main/java/com/flansmod/common/network/PacketTeamInfo.java
@@ -1,21 +1,22 @@
 package com.flansmod.common.network;
 
-import java.util.ArrayList;
-import java.util.Collections;
-
 import com.flansmod.client.FlansModClient;
 import com.flansmod.common.PlayerData;
 import com.flansmod.common.PlayerHandler;
 import com.flansmod.common.teams.PlayerClass;
 import com.flansmod.common.teams.Team;
 import com.flansmod.common.teams.TeamsManager;
-
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraftforge.fml.common.FMLCommonHandler;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.UUID;
 
 public class PacketTeamInfo extends PacketBase 
 {			
@@ -118,9 +119,11 @@ public class PacketTeamInfo extends PacketBase
 						data.writeInt(team.members.size());
 						for(int j = 0; j < team.members.size(); j++)
 						{
-							String username = team.members.get(j);
-							PlayerData playerData = PlayerHandler.getPlayerData(username, Side.SERVER);
-							writeUTF(data, username);
+							UUID uuid = team.members.get(j);
+							String userName = FMLCommonHandler.instance().getMinecraftServerInstance().getPlayerList().getPlayerByUUID(uuid).getName();
+							PlayerData playerData = PlayerHandler.getPlayerData(uuid, Side.SERVER);
+							writeUTF(data, userName);
+
 							if(playerData == null)
 							{
 								data.writeInt(0);
@@ -143,7 +146,7 @@ public class PacketTeamInfo extends PacketBase
 			else
 			{
 				data.writeBoolean(false);
-				ArrayList<String> playerNames = new ArrayList<String>();
+				ArrayList<UUID> playerNames = new ArrayList<UUID>();
 				for(int i = 0; i < TeamsManager.getInstance().currentRound.teams.length; i++)
 				{
 					Team team = TeamsManager.getInstance().currentRound.teams[i];
@@ -156,8 +159,9 @@ public class PacketTeamInfo extends PacketBase
 
 				Collections.sort(playerNames, new Team.ComparatorScore());
 				data.writeInt(playerNames.size());
-				for (String username : playerNames) {
-					PlayerData playerData = PlayerHandler.getPlayerData(username, Side.SERVER);
+				for (UUID uuid : playerNames) {
+					PlayerData playerData = PlayerHandler.getPlayerData(uuid, Side.SERVER);
+					String username = FMLCommonHandler.instance().getMinecraftServerInstance().getPlayerList().getPlayerByUUID(uuid).getName();
 					writeUTF(data, username);
 					if (playerData == null) {
 						data.writeInt(0);

--- a/src/main/java/com/flansmod/common/teams/EntityFlag.java
+++ b/src/main/java/com/flansmod/common/teams/EntityFlag.java
@@ -1,10 +1,7 @@
 package com.flansmod.common.teams;
 
-import javax.annotation.Nullable;
-
 import com.flansmod.common.FlansMod;
 import com.flansmod.common.PlayerHandler;
-
 import net.fexcraft.mod.lib.util.entity.EntUtil;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
@@ -14,6 +11,8 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.EnumHand;
 import net.minecraft.util.math.RayTraceResult;
 import net.minecraft.world.World;
+
+import javax.annotation.Nullable;
 
 public class EntityFlag extends Entity implements ITeamObject {
 	
@@ -64,7 +63,7 @@ public class EntityFlag extends Entity implements ITeamObject {
 			if(getPassengers() instanceof EntityPlayerMP)
 			{
 				EntityPlayerMP player = ((EntityPlayerMP)getPassengers());
-				Team team = PlayerHandler.getPlayerData(player.getName()).team;
+				Team team = PlayerHandler.getPlayerData(player.getUniqueID()).team;
 				TeamsManager.getInstance();
 				TeamsManager.messageAll("\u00a7f" + player.getName() + " dropped the \u00a7" + team.textColour + team.name + "\u00a7f flag");
 			}

--- a/src/main/java/com/flansmod/common/teams/Team.java
+++ b/src/main/java/com/flansmod/common/teams/Team.java
@@ -1,17 +1,11 @@
 package com.flansmod.common.teams;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.List;
-
 import com.flansmod.common.FlansMod;
 import com.flansmod.common.PlayerData;
 import com.flansmod.common.PlayerHandler;
 import com.flansmod.common.types.EnumType;
 import com.flansmod.common.types.InfoType;
 import com.flansmod.common.types.TypeFile;
-
 import net.minecraft.client.model.ModelBase;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
@@ -19,10 +13,12 @@ import net.minecraft.item.ItemStack;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
+import java.util.*;
+
 public class Team extends InfoType
 {
 	public static List<Team> teams = new ArrayList<Team>();
-	public List<String> members = new ArrayList<String>();
+	public List<UUID> members = new ArrayList<UUID>();
 	//public List<ITeamBase> bases = new ArrayList<ITeamBase>();
 	public List<PlayerClass> classes = new ArrayList<PlayerClass>();
 	
@@ -180,42 +176,47 @@ public class Team extends InfoType
 	
 	public void removePlayer(EntityPlayer player)
 	{
-		removePlayer(player.getName());
+		removePlayer(player.getUniqueID());
 	}
 	
-	public String removePlayer(String username)
+	public UUID removePlayer(UUID uuid)
 	{
-		members.remove(username);
-		if(PlayerHandler.getPlayerData(username) != null)
-			PlayerHandler.getPlayerData(username).team = null;
-		return username;
+		members.remove(uuid);
+		if(PlayerHandler.getPlayerData(uuid) != null)
+			PlayerHandler.getPlayerData(uuid).team = null;
+		return uuid;
 	}
 	
 	public EntityPlayer addPlayer(EntityPlayer player)
 	{
-		addPlayer(player.getName());
+		addPlayer(player.getUniqueID());
 		return player;
 	}
 	
-	public String addPlayer(String username)
+	public UUID addPlayer(UUID uuid)
 	{
-		ArrayList<String> list = new ArrayList<String>();
-		list.add(username);
+		ArrayList<UUID> list = new ArrayList<UUID>();
+		list.add(uuid);
 		for(Team team : teams)
 		{
 			team.members.removeAll(list);
 		}
-		members.add(username);
-		PlayerHandler.getPlayerData(username).newTeam = PlayerHandler.getPlayerData(username).team = this;
-		return username;
+		members.add(uuid);
+		PlayerHandler.getPlayerData(uuid).newTeam = PlayerHandler.getPlayerData(uuid).team = this;
+		return uuid;
 	}
 	
-	public String removeWorstPlayer()
+	public UUID removeWorstPlayer()
 	{
 		sortPlayers();
 		if(members.size() == 0)
+		{
 			return null;
-		else return removePlayer(members.get(members.size() - 1));
+		}
+		else
+		{
+			return removePlayer(members.get(members.size() - 1));
+		}
 	}
 	
 	public void sortPlayers()
@@ -223,10 +224,10 @@ public class Team extends InfoType
 		Collections.sort(members, new ComparatorScore());
 	}
 	
-	public static class ComparatorScore implements Comparator<String>
+	public static class ComparatorScore implements Comparator<UUID>
 	{
 		@Override
-		public int compare(String a, String b) 
+		public int compare(UUID a, UUID b)
 		{
 			PlayerData dataA = PlayerHandler.getPlayerData(a);
 			PlayerData dataB = PlayerHandler.getPlayerData(b);

--- a/src/main/java/com/flansmod/common/teams/TeamsManager.java
+++ b/src/main/java/com/flansmod/common/teams/TeamsManager.java
@@ -1,35 +1,13 @@
 package com.flansmod.common.teams;
 
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.EnumSet;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-
 import com.flansmod.common.FlansMod;
 import com.flansmod.common.PlayerData;
 import com.flansmod.common.PlayerHandler;
 import com.flansmod.common.driveables.ItemPlane;
 import com.flansmod.common.driveables.ItemVehicle;
-import com.flansmod.common.guns.GunType;
-import com.flansmod.common.guns.ItemAAGun;
-import com.flansmod.common.guns.ItemBullet;
-import com.flansmod.common.guns.ItemGun;
-import com.flansmod.common.guns.ItemShootable;
-import com.flansmod.common.guns.ShootableType;
-import com.flansmod.common.network.PacketBase;
-import com.flansmod.common.network.PacketRoundFinished;
-import com.flansmod.common.network.PacketTeamInfo;
-import com.flansmod.common.network.PacketTeamSelect;
-import com.flansmod.common.network.PacketVoting;
+import com.flansmod.common.guns.*;
+import com.flansmod.common.network.*;
 import com.flansmod.common.types.InfoType;
-
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.player.EntityPlayer;
@@ -63,6 +41,9 @@ import net.minecraftforge.fml.common.FMLCommonHandler;
 import net.minecraftforge.fml.common.eventhandler.Event;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.gameevent.PlayerEvent;
+
+import java.io.*;
+import java.util.*;
 
 public class TeamsManager
 {
@@ -290,7 +271,7 @@ public class TeamsManager
 			{
 				//My goodness this is convoluted...
 				EntityPlayerMP playerToKick = getPlayer(currentRound.teams[1].addPlayer(currentRound.teams[0].removeWorstPlayer()));
-				this.messagePlayer(playerToKick, "You were moved to the other team by the autobalancer.");
+				messagePlayer(playerToKick, "You were moved to the other team by the autobalancer.");
 				sendClassMenuToPlayer(playerToKick);
 			}
 		}
@@ -299,7 +280,7 @@ public class TeamsManager
 			for(int i = 0; i < (membersTeamB - membersTeamA) / 2; i++)
 			{
 				EntityPlayerMP playerToKick = getPlayer(currentRound.teams[0].addPlayer(currentRound.teams[1].removeWorstPlayer()));
-				this.messagePlayer(playerToKick, "You were moved to the other team by the autobalancer.");
+				messagePlayer(playerToKick, "You were moved to the other team by the autobalancer.");
 				sendClassMenuToPlayer(playerToKick);
 			}
 		}
@@ -1321,9 +1302,9 @@ public class TeamsManager
 		objects.add(obj);
 	}
 	
-	public EntityPlayerMP getPlayer(String username)
+	public EntityPlayerMP getPlayer(UUID uuid)
 	{
-		return FMLCommonHandler.instance().getMinecraftServerInstance().getPlayerList().getPlayerByUsername(username);
+		return FMLCommonHandler.instance().getMinecraftServerInstance().getPlayerList().getPlayerByUUID(uuid);
 	}
 	
 	public static void log(String s)


### PR DESCRIPTION
I found a bug where guns wouldn't work after the player died.

Everytime a player dies, the server seems to create a new instance of EntityPlayerMP. The PlayerQueue in PacketHandler still contains the old player.
I used a HashMap<UUID, PlayerQueue> for receivedPacketsServer to make sure that there is only one PlayerQueue per player.

Probably needs testing